### PR TITLE
Add Actor dropdown menu selects appropriate actor type

### DIFF
--- a/Dnd-Combat-Tracker/TableModel.cpp
+++ b/Dnd-Combat-Tracker/TableModel.cpp
@@ -16,6 +16,7 @@ void TableModel::InitializeAddActorTable(QTableWidget *addActors)
     addActors->clearContents();
     addActors->setColumnCount(ActorListColCount);
     addActors->setHorizontalHeaderLabels(ActorListColNames);
+    addActors->hideColumn(A_TYPE);
 }
 
 void TableModel::PopulateAddActorTable(QTableWidget *addActors, QVector<Actor>* actorList)
@@ -57,6 +58,8 @@ void TableModel::PopulateAddActorTable(QTableWidget *addActors, QVector<Actor>* 
         addActors->setItem(index, A_DC, dcItemList.at(index));
             // Notes
         addActors->setItem(index, A_NOTES, new QTableWidgetItem(actorList->at(index).GetNotes()));
+            // Type
+        addActors->setItem(index, A_TYPE, new QTableWidgetItem(actorList->at(index).GetType()));
     }
 }
 
@@ -77,7 +80,6 @@ void TableModel::MoveActorToTable(QTableWidget* origin, QTableWidget* destinatio
 
     // Get selected row index
     int selectedRow = origin->currentItem()->row();
-
 
     // Load the data into the attribute, then load it into the listing
     for(int index = 0; index < ActorListColCount; index++)
@@ -107,8 +109,31 @@ void TableModel::MoveActorToTable(QTableWidget* origin, QTableWidget* destinatio
 
     // Delete old table's listing
     origin->removeRow(selectedRow);
+}
 
-    // END void MoveActorToTable(QTableWidget* origin, QTableWidget* destination); //
+// Add Actors - Show selected actor type in actor list
+void TableModel::ShowActorType(QTableWidget* addActors, const QString &type)
+{
+    bool match = false;
+
+    // Show all rows (initialize)
+    for(int index = 0; index < addActors->rowCount(); index++)
+    {
+        addActors->showRow(index);
+    }
+
+    // Hide actors not found
+    for(int index = 0; index < addActors->rowCount(); index++)
+    {
+        // Set match to false
+        match = false;
+
+        // Check to see if listing matches type
+        match = addActors->item(index, 5)->data(0).toString() == type;
+
+        // If not, hide it
+        if(!match) { addActors->hideRow(index); }
+    }
 }
 
 // Constructor

--- a/Dnd-Combat-Tracker/TableModel.cpp
+++ b/Dnd-Combat-Tracker/TableModel.cpp
@@ -91,10 +91,6 @@ void TableModel::MoveActorToTable(QTableWidget* origin, QTableWidget* destinatio
     QVector<QTableWidgetItem*> actorListing;
     QTableWidgetItem* actorAttribute = nullptr;
     QTableWidgetItem* tempListing = nullptr;
-    bool empty = origin->rowCount() == 0;
-
-    // Get selected row index
-    int selectedRow = origin->currentItem()->row();
 
     // Load the data into the attribute, then load it into the listing
     for(int index = 0; index < ActorListColCount; index++)
@@ -131,6 +127,7 @@ void TableModel::MoveActorToTable(QTableWidget* origin, QTableWidget* destinatio
         // Delete old table's listing
         origin->removeRow(selectedRow);
     } // END if(!empty)
+}
 
 // Add Actors - Show selected actor type in actor list
 void TableModel::ShowActorType(QTableWidget* addActors, const QString &type)

--- a/Dnd-Combat-Tracker/TableModel.h
+++ b/Dnd-Combat-Tracker/TableModel.h
@@ -20,10 +20,10 @@ public:
     QStringList CombatColNames = { "Name", "HP: Cur", "Max", "AC", "DC", "Init", "Notes" };
         // Actor List Model
     // Column Count
-    const int ActorListColCount = 5;
+    const int ActorListColCount = 6;
 
     // Column Positions
-    enum ActorListColPositions { A_NAME, A_HP, A_AC, A_DC, A_NOTES };
+    enum ActorListColPositions { A_NAME, A_HP, A_AC, A_DC, A_NOTES, A_TYPE };
 
     // Column Names
     QStringList ActorListColNames = { "Name", "HP", "AC", "DC", "Notes" };
@@ -51,6 +51,9 @@ public:
 
     // Move actor from one table to the other
     void MoveActorToTable(QTableWidget* origin, QTableWidget* destination);
+
+    // Add Actors - Show selected actor type in actor list
+    void ShowActorType(QTableWidget* addActors, const QString &type);
 
     // Constructor
     TableModel();

--- a/Dnd-Combat-Tracker/mainwindow.cpp
+++ b/Dnd-Combat-Tracker/mainwindow.cpp
@@ -24,6 +24,14 @@ MainWindow::MainWindow(QWidget *parent)
 
     // Populate list of partymembers
     db->CreatePartyList();
+
+    // START COMBOBOX INITIALIZATION
+
+    // Populate Combobox
+    ui->showActors_comboBox->addItems(addActorsComboBoxLabels);
+
+    // END COMBOBOX INITIALIZATION
+
 }
 
 MainWindow::~MainWindow()
@@ -35,6 +43,9 @@ MainWindow::~MainWindow()
 void MainWindow::on_welcomeStart_pushButton_clicked()
 {
     ui->main_stackedWidget->setCurrentIndex(EDIT);
+
+    // Ensure combobox displays proper index
+    ui->showActors_comboBox->setCurrentIndex(0);
 
     // Populate "Actors" TableWidget
         // Initialize/Clear TableWidget
@@ -67,6 +78,9 @@ void MainWindow::on_next_editPage_pushButton_clicked()
 void MainWindow::on_back_assignInit_pushButton_clicked()
 {
     ui->main_stackedWidget->setCurrentIndex(EDIT);
+
+    // Ensure combobox displays proper index
+    ui->showActors_comboBox->setCurrentIndex(0);
 }
 
 // Navigates user to combat page from assign initiative page
@@ -121,15 +135,35 @@ void MainWindow::format_dbEdit_tableView()
     ui->dbEdit_tableView->setColumnWidth(1, 200);
 }
 
-// 'Adds' character to combat by moving actor listing from actor list to combat list
+// 'Adds' actor to combat list by moving actor listing from actor list to combat list
 void MainWindow::on_addActor_pushButton_clicked()
 {
     // Move selected actor from "Add Actor" table to "Combat" Table
     tableManager->MoveActorToTable(ui->actorTable_tableWidget, ui->combatTable_tableWidget);
 }
 
+// 'Removes' actor from combat list by moving actor listing from combat list to actor list
 void MainWindow::on_deleteActor_pushButton_clicked()
 {
     // Move selected actor from "Add Actor" table to "Combat" Table
     tableManager->MoveActorToTable(ui->combatTable_tableWidget, ui->actorTable_tableWidget);
+}
+
+// Filters displayed actors by type
+void MainWindow::on_showActors_comboBox_activated(int index)
+{
+    switch(index)
+    {
+        case ALL: for(int index = 0; index < ui->actorTable_tableWidget->rowCount(); index++) { ui->actorTable_tableWidget->showRow(index); }
+            break;
+        case PARTY: tableManager->ShowActorType(ui->actorTable_tableWidget, "partymember");
+            break;
+        case CREATURES: tableManager->ShowActorType(ui->actorTable_tableWidget, "creature");
+            break;
+        case COMPANIONS: tableManager->ShowActorType(ui->actorTable_tableWidget, "companion");
+            break;
+        case EFFECTS: tableManager->ShowActorType(ui->actorTable_tableWidget, "effect");
+            break;
+        default: break;
+    }
 }

--- a/Dnd-Combat-Tracker/mainwindow.h
+++ b/Dnd-Combat-Tracker/mainwindow.h
@@ -17,6 +17,11 @@ class MainWindow : public QMainWindow
 public:
     enum  pages {WELCOME, EDIT, ASSIGN, COMBAT, DB_EDIT};
 
+    // Add Actors Page ComboBox
+    enum  addActorsComboBox { ALL, PARTY, CREATURES, COMPANIONS, EFFECTS};
+
+    QStringList addActorsComboBoxLabels = { "All Actors", "Partymembers", "Creatures", "Companions", "Effects" };
+
     MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
 
@@ -45,6 +50,8 @@ private slots:
     void on_addActor_pushButton_clicked();
 
     void on_deleteActor_pushButton_clicked();
+
+    void on_showActors_comboBox_activated(int index);
 
 private:
     Ui::MainWindow *ui;


### PR DESCRIPTION
Bug:
If you go back to main menu, then forward to 'add actors' and change the qcombobox to display a different type of creature, it will crash

Pretty sure it's caused by the previous bug that I fixed earlier