### PR TITLE
Addactorform addtodb & bug fixes

### DIFF
--- a/Dnd-Combat-Tracker/AddActorForm.h
+++ b/Dnd-Combat-Tracker/AddActorForm.h
@@ -19,10 +19,10 @@ public:
     ~AddActorForm();
 
      // Inserts actor to combat table
-     void SubmitPremadeActor();
+     Actor* GetPremadeActor();
 
      // Stores data from add custom fields in an actor & inserts actor to combat table
-     void SubmitCustomActor();
+     Actor* GetCustomActor();
 
      // Initializes modal window pages & sets current index to the menu
      void Initialize();
@@ -71,7 +71,7 @@ private slots:
      void on_cancel_setInit_pushButton_clicked();
 
      // Inserts the passed in actor, with the passed in quantity, to the setInit table widget
-     void InsertActorToSetInit(Actor actor, int qty);
+     void InsertActorToSetInit(Actor* actor, int qty);
 
      // Initializes formatting for setInit table widget
      void InitializeInitTable();
@@ -85,14 +85,18 @@ private slots:
      // Inserts each actor from the setInit table into the combat table on mainwindow
      void AddToCombat();
 
+     // Checks if typed in actor name is already in the user base as user is typing
      void on_name_custom_lineEdit_textChanged(const QString &arg1);
 
+     // Changes displayed names in premade actor combo box to match the current scenario
      void UpdatePremadeActors();
+
+     //  Adds custom actor to database
+     void AddCustomActorToDB();
 
 private:
     Ui::AddActorForm *ui;
     Database *db;
-//    QVector<Actor>* actorList;
     Actor createdActor;
     QTableWidget *combat;
     int initCancelButtonIndex;

--- a/Dnd-Combat-Tracker/CombatManager.cpp
+++ b/Dnd-Combat-Tracker/CombatManager.cpp
@@ -69,6 +69,8 @@ void CombatManager::InsertActorToCombat(Actor actor, int init)
 
     row = FindInsertRow(init);
 
+    qDebug() << row;
+
     combat->insertRow(row);
 
     // Handles which data will be placed on the table depending on the column
@@ -256,15 +258,15 @@ int CombatManager::FindInsertRow(int initiative)
     // Divider is in last row
     if(divIsLast)
     {
-        if(firstGreater)
-        {
-            first = divRow + 1;
-            last = combat->rowCount() - 1;
-        }
-        else // New actor init greater than current turn init
+        if(firstGreater) // Actor gets inserted into current round
         {
             first = 0;
             last = divRow - 1;
+        }
+        else // New actor init greater than current turn init
+        {
+            first = divRow + 1;
+            last = first;
         }
     }
     else // Divider anywhere else in table
@@ -284,7 +286,7 @@ int CombatManager::FindInsertRow(int initiative)
     // Init will be placed above/below divider on side where only one row exists
     if(first == last)
     {
-        insertAtRow = last + 1;
+        insertAtRow = last;
     }
     // Divider is anywhere else in combat table
     else

--- a/Dnd-Combat-Tracker/CombatManager.cpp
+++ b/Dnd-Combat-Tracker/CombatManager.cpp
@@ -69,8 +69,6 @@ void CombatManager::InsertActorToCombat(Actor actor, int init)
 
     row = FindInsertRow(init);
 
-    qDebug() << row;
-
     combat->insertRow(row);
 
     // Handles which data will be placed on the table depending on the column
@@ -382,7 +380,7 @@ void CombatManager::CheckForTie()
         tiePrompt.resize(400, 200);
 
         // Display input dialog modal window with combobox of actors to select from
-        selectedTurn = tiePrompt.getItem(combat, "TIE!", "Please select which actor will go this turn:", names);
+        selectedTurn = tiePrompt.getItem(combat, "TIE!", "Please select which actor will go this turn:", names, 0, false);
 
         // Moves the selected actor to the first position in the list
         if(selectedTurn != combat->item(0, NAME)->text())

--- a/Dnd-Combat-Tracker/CombatManager.cpp
+++ b/Dnd-Combat-Tracker/CombatManager.cpp
@@ -301,7 +301,7 @@ int CombatManager::FindInsertRow(int initiative)
             }
             else // Add to end of list
             {
-                insertAtRow = row + 1;
+                insertAtRow = row;
             }
 
             row++;

--- a/Dnd-Combat-Tracker/CombatManager.h
+++ b/Dnd-Combat-Tracker/CombatManager.h
@@ -45,8 +45,11 @@ public:
     // Searches combat for divider row location
     int GetDividerLocation();
 
+    // Checks the combat table for a tied initiative and prompts the user to select which
+    //      actor will take the current turn
     void CheckForTie();
 
+    // Searches the combat table for the passed in actor and returns their row number
     int FindActorByName(QString name);
 private:
     QTableWidget *combat;

--- a/Dnd-Combat-Tracker/addactorform.ui
+++ b/Dnd-Combat-Tracker/addactorform.ui
@@ -557,7 +557,29 @@
        </widget>
       </item>
       <item>
-       <widget class="QTableWidget" name="setInit_tableWidget"/>
+       <widget class="QTableWidget" name="setInit_tableWidget">
+        <property name="editTriggers">
+         <set>QAbstractItemView::NoEditTriggers</set>
+        </property>
+        <property name="selectionMode">
+         <enum>QAbstractItemView::NoSelection</enum>
+        </property>
+        <property name="selectionBehavior">
+         <enum>QAbstractItemView::SelectRows</enum>
+        </property>
+        <attribute name="horizontalHeaderDefaultSectionSize">
+         <number>200</number>
+        </attribute>
+        <attribute name="horizontalHeaderStretchLastSection">
+         <bool>true</bool>
+        </attribute>
+        <attribute name="verticalHeaderVisible">
+         <bool>false</bool>
+        </attribute>
+        <attribute name="verticalHeaderHighlightSections">
+         <bool>false</bool>
+        </attribute>
+       </widget>
       </item>
       <item>
        <spacer name="verticalSpacer_3">

--- a/Dnd-Combat-Tracker/mainwindow.cpp
+++ b/Dnd-Combat-Tracker/mainwindow.cpp
@@ -16,11 +16,11 @@ MainWindow::MainWindow(QWidget *parent)
 
     FormatEditActorsTableView();
 
-    tableManager = new TableModel;
+    tableManager = new TableModel();
 
     // Create tablewidgets
-    combatTable = new QTableWidget;
-    assignInit = new QTableWidget;
+    combatTable = new QTableWidget();
+    assignInit = new QTableWidget();
     combatManager = new CombatManager(ui->activeCombatTable_tableWidget);
 
     // Populate Combobox
@@ -30,10 +30,6 @@ MainWindow::MainWindow(QWidget *parent)
     _saved = true;
 
     addActorForm = new AddActorForm(nullptr, db, ui->activeCombatTable_tableWidget);
-
-    ui->welcomeStart_pushButton->click();
-    ui->next_editPage_pushButton->click();
-    ui->fight_assignInit_pushButton->click();
 
     // DEBUG
     // Create scenario listings

--- a/Dnd-Combat-Tracker/mainwindow.cpp
+++ b/Dnd-Combat-Tracker/mainwindow.cpp
@@ -31,6 +31,10 @@ MainWindow::MainWindow(QWidget *parent)
 
     addActorForm = new AddActorForm(nullptr, db, ui->activeCombatTable_tableWidget);
 
+    ui->welcomeStart_pushButton->click();
+    ui->next_editPage_pushButton->click();
+    ui->fight_assignInit_pushButton->click();
+
     // DEBUG
     // Create scenario listings
     listings = new QVector<ScenarioListing>;

--- a/Dnd-Combat-Tracker/mainwindow.h
+++ b/Dnd-Combat-Tracker/mainwindow.h
@@ -189,9 +189,9 @@ private:
     CombatManager *combatManager;
 
     // Models
-    DbEditTableModel *editActorsModel = nullptr;
-    DbEditTableModel *editScenarioModel = nullptr;
-    DbEditTableModel *editScenarioActorsModel = nullptr;
+    DbEditTableModel *editActorsModel;
+    DbEditTableModel *editScenarioModel;
+    DbEditTableModel *editScenarioActorsModel;
 
     // DEBUG: Previous index checking
     QVector<ScenarioListing> *listings = nullptr;


### PR DESCRIPTION
**Changes**
- Implemented adding custom actor to database
- Fixed bug in add actor mid combat where new actor with init = current turn init would not add to table
- Fixed tie breaker bug where user could edit item in text box
- Added formatting to set init table
- Fixed bug in add actor mid combat where adding multiple actors to next round didn't insert them in correct order

****

**Known issues**
- Have not fixed adding an actor already in combat and handling correct name with qty number
- In some cases, adding custom actor may accept just spaces